### PR TITLE
Add delivery and service roles for o2 monitoring

### DIFF
--- a/global/iam/introductions-bot.tf
+++ b/global/iam/introductions-bot.tf
@@ -12,3 +12,8 @@ resource "aws_iam_role" "delivery-introductions-bot" {
   path = "/services/"
   assume_role_policy = file("${path.module}/templates/assume_role_policy/codebuild.json")
 }
+
+resource "aws_iam_role_policy_attachment" "delivery-introductions-bot" {
+  role =  aws_iam_role.delivery-introductions-bot.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/global/iam/monitoring-02.tf
+++ b/global/iam/monitoring-02.tf
@@ -1,0 +1,19 @@
+# Define the O2 monitoring project's principals in sandbox.
+
+# IAM user for CI/CD
+resource "aws_iam_user" "delivery-monitoring-O2" {
+  name = "delivery-monitoring-O2"
+  path = "/services/"
+}
+
+# Service role for the application to run as
+resource "aws_iam_role" "monitoring-O2" {
+  name = "svc-monitoring-O2"
+  path = "/services/"
+  assume_role_policy = file("${path.module}/templates/assume_role_policy/ec2.json")
+}
+
+resource "aws_iam_role_policy_attachment" "monitoring-O2" {
+  role =  aws_iam_role.delivery-introductions-bot.name
+  policy_arn = "arn:aws:iam::aws:policy/PowerUser"
+}

--- a/global/iam/monitoring-02.tf
+++ b/global/iam/monitoring-02.tf
@@ -14,6 +14,6 @@ resource "aws_iam_role" "monitoring-O2" {
 }
 
 resource "aws_iam_role_policy_attachment" "monitoring-O2" {
-  role =  aws_iam_role.delivery-introductions-bot.name
+  role =  aws_iam_role.monitoring-O2.name
   policy_arn = "arn:aws:iam::aws:policy/PowerUser"
 }

--- a/global/iam/shared-delivery.tf
+++ b/global/iam/shared-delivery.tf
@@ -27,15 +27,8 @@ resource "aws_iam_group_membership" "delivery" {
   users = [
     aws_iam_user.delivery-devops.name,
     aws_iam_user.delivery-introductions-bot.name,
+    aws_iam_user.delivery-monitoring-O2.name,
   ]
 
   group = aws_iam_group.delivery.name
-}
-
-resource "aws_iam_policy_attachment" "delivery" {
-  name = "delivery-membership"
-  roles = [
-    aws_iam_role.delivery-introductions-bot.name
-  ]
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }

--- a/global/iam/templates/assume_role_policy/ec2.json
+++ b/global/iam/templates/assume_role_policy/ec2.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": "AllowAssumeRoleForEC2"
+    }
+  ]
+}


### PR DESCRIPTION
* Create a delivery role for CI/CD
* Create a service role to operate the application
* Update policy attachment for delivery roles so they are not exclusive